### PR TITLE
Make BuildHierarchy.directBuildParentsOf recursion-safe

### DIFF
--- a/src/test/kotlin/dev/panuszewski/gradle/IncludedBuildSpec.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/IncludedBuildSpec.kt
@@ -1,14 +1,15 @@
 package dev.panuszewski.gradle
 
+import dev.panuszewski.gradle.fixtures.CyclicBuildHierarchy
 import dev.panuszewski.gradle.fixtures.EmbeddedKotlinUsage
 import dev.panuszewski.gradle.fixtures.LibsInIncludedBuild
 import dev.panuszewski.gradle.fixtures.PluginMarkerUsage
-import dev.panuszewski.gradle.fixtures.includedbuild.PluginManagementBuildLogic
 import dev.panuszewski.gradle.framework.BuildOutcome.BUILD_SUCCESSFUL
 import dev.panuszewski.gradle.framework.Fixture
 import dev.panuszewski.gradle.framework.GradleSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 
@@ -98,6 +99,18 @@ class IncludedBuildSpec : GradleSpec() {
 
         // when
         val result = runGradle("help")
+
+        // then
+        result.buildOutcome shouldBe BUILD_SUCCESSFUL
+    }
+
+    @Test
+    fun `cyclic includes should be possible`() {
+        // given
+        installFixture(CyclicBuildHierarchy)
+
+        // when
+        val result = runGradle("dependencies")
 
         // then
         result.buildOutcome shouldBe BUILD_SUCCESSFUL

--- a/src/test/kotlin/dev/panuszewski/gradle/fixtures/CyclicBuildHierarchy.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/fixtures/CyclicBuildHierarchy.kt
@@ -1,0 +1,61 @@
+package dev.panuszewski.gradle.fixtures
+
+import dev.panuszewski.gradle.framework.GradleSpec
+import dev.panuszewski.gradle.framework.NoConfigFixture
+
+object CyclicBuildHierarchy : NoConfigFixture {
+    override fun GradleSpec.install() {
+        val secondaryBuild = mainBuild.registerIncludedBuild("secondary-build")
+        val buildLogic = mainBuild.registerIncludedBuild("build-logic")
+        secondaryBuild.includeBuild("..")
+
+        with(mainBuild) {
+            buildGradleKts {
+                """
+                plugins {
+                    java
+                }
+                """
+            }
+        }
+
+        with(secondaryBuild) {
+            buildGradleKts {
+                """
+                plugins {
+                    java
+                }
+                """
+            }
+        }
+
+        with(buildLogic) {
+            settingsGradleKts {
+                """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                        mavenLocal()
+                    }
+                }
+                    
+                plugins {
+                    id("dev.panuszewski.typesafe-conventions") version "$projectVersion"
+                }
+                """
+            }
+
+            buildGradleKts {
+                """
+                plugins {
+                    `kotlin-dsl`
+                } 
+                
+                repositories {
+                    mavenCentral()
+                }
+                """
+            }
+        }
+    }
+}

--- a/src/test/kotlin/dev/panuszewski/gradle/framework/GradleBuild.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/framework/GradleBuild.kt
@@ -87,12 +87,16 @@ class GradleBuild(
             .acceptConfigurator(configurator)
     }
 
-    fun registerIncludedBuild(buildPath: String): GradleBuild {
+    fun includeBuild(buildPath: String) {
         settingsGradleKts.append {
             """
             includeBuild("$buildPath")    
             """
         }
+    }
+
+    fun registerIncludedBuild(buildPath: String): GradleBuild {
+        includeBuild(buildPath)
         val buildDir = rootDir.resolve(buildPath)
         val buildName = buildDir.name
         return GradleBuild(buildName, buildDir, gradleVersion)


### PR DESCRIPTION
The old implementation ran into stack overflows, in case of cyclic includeBuild()s, this new implementation changes the map key to the identity path of the projects and recurses only, if the project doesn't already have an entry in the map. This is also more efficient and given that Gradle/GradleInternal impls don't implement equals and hashCode probably also safer in the long run.

This project triggers this case: https://github.com/pschichtel/libdatachannel-java, once you update it to 0.8.0. This PR is successfully tested against that project.