### PR TITLE
Stable order of parsed plugin declarations

### DIFF
--- a/src/main/kotlin/dev/panuszewski/gradle/versioncatalogs/PluginVersionCatalogAccessors.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/versioncatalogs/PluginVersionCatalogAccessors.kt
@@ -40,6 +40,8 @@ private fun collectPluginDeclarations(project: Project, catalog: VersionCatalogB
         .map(::removeComments)
         .flatMap(String::lines)
         .mapNotNull { line -> parsePluginDeclaration(line, model) }
+        // We use Set to remove potential duplicates when multiple conventions apply the same plugin.
+        // There is no observable behavior change when the same dependency is added multiple times, thus no test covers this case.
         .toSortedSet(compareBy { it.pluginAlias })
 }
 

--- a/src/main/kotlin/dev/panuszewski/gradle/versioncatalogs/PluginVersionCatalogAccessors.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/versioncatalogs/PluginVersionCatalogAccessors.kt
@@ -31,7 +31,7 @@ internal fun configurePluginVersionCatalogAccessors(project: Project, catalog: V
     }
 }
 
-private fun collectPluginDeclarations(project: Project, catalog: VersionCatalogBuilderInternal): List<PluginDeclaration> {
+private fun collectPluginDeclarations(project: Project, catalog: VersionCatalogBuilderInternal): Collection<PluginDeclaration> {
     val model = catalog.build()
 
     return project.sourceSets["main"].kotlin.asFileTree
@@ -40,7 +40,7 @@ private fun collectPluginDeclarations(project: Project, catalog: VersionCatalogB
         .map(::removeComments)
         .flatMap(String::lines)
         .mapNotNull { line -> parsePluginDeclaration(line, model) }
-        .toList()
+        .toSortedSet(compareBy { it.pluginAlias })
 }
 
 private fun removeComments(sourceCode: String): String =
@@ -83,7 +83,7 @@ private fun writeCatalogEntrypointBeforeCompilation(project: Project, catalog: V
     }
 }
 
-private fun patchPluginsBlocksAfterExtraction(project: Project, pluginDeclarations: List<PluginDeclaration>) {
+private fun patchPluginsBlocksAfterExtraction(project: Project, pluginDeclarations: Collection<PluginDeclaration>) {
     project.plugins.withId("org.gradle.kotlin.kotlin-dsl") {
         // we add action to an existing task instead of registering a dedicated task to allow caching
         // (otherwise the dedicated task would modify its own input and never be UP-TO-DATE)
@@ -100,7 +100,7 @@ private fun patchPluginsBlocksAfterExtraction(project: Project, pluginDeclaratio
     }
 }
 
-private fun patchPluginsBlock(pluginsBlockFile: File, pluginDeclarations: List<PluginDeclaration>) {
+private fun patchPluginsBlock(pluginsBlockFile: File, pluginDeclarations: Collection<PluginDeclaration>) {
     var content = pluginsBlockFile.readText()
 
     pluginDeclarations.forEach {
@@ -110,7 +110,7 @@ private fun patchPluginsBlock(pluginsBlockFile: File, pluginDeclarations: List<P
     pluginsBlockFile.writeText(content)
 }
 
-private fun addPluginMarkerDependencies(project: Project, pluginDeclarations: List<PluginDeclaration>) {
+private fun addPluginMarkerDependencies(project: Project, pluginDeclarations: Collection<PluginDeclaration>) {
     pluginDeclarations.forEach {
         project.dependencies.add("implementation", it.pluginMarkerWithoutVersion) {
             version { prefer(it.pluginVersionFromStrongestConstraint) }

--- a/src/test/kotlin/dev/panuszewski/gradle/ConventionPluginsSpec.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/ConventionPluginsSpec.kt
@@ -9,6 +9,7 @@ import dev.panuszewski.gradle.fixtures.LibsInPluginsBlockInCustomLocation
 import dev.panuszewski.gradle.fixtures.MultiLevelBuildHierarchy
 import dev.panuszewski.gradle.fixtures.MultipleCatalogsInDependenciesBlock
 import dev.panuszewski.gradle.fixtures.MultipleCatalogsInPluginsBlock
+import dev.panuszewski.gradle.fixtures.MultipleConventionPlugins
 import dev.panuszewski.gradle.fixtures.OverriddenPluginVersion
 import dev.panuszewski.gradle.fixtures.TopLevelBuild
 import dev.panuszewski.gradle.fixtures.TypesafeConventionsConfig
@@ -17,7 +18,9 @@ import dev.panuszewski.gradle.framework.BuildOutcome.BUILD_FAILED
 import dev.panuszewski.gradle.framework.BuildOutcome.BUILD_SUCCESSFUL
 import dev.panuszewski.gradle.framework.Fixture
 import dev.panuszewski.gradle.framework.GradleSpec
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.containInOrder
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import org.gradle.util.GradleVersion
@@ -323,5 +326,21 @@ class ConventionPluginsSpec : GradleSpec() {
 
         // then
         result.buildOutcome shouldBe BUILD_FAILED
+    }
+
+    @ParameterizedTest
+    @SupportedIncludedBuilds
+    fun `should order plugin marker dependencies by alias`(includedBuild: Fixture<*>) {
+        // given
+        installFixture(includedBuild)
+        val fixture = installFixture(MultipleConventionPlugins)
+
+        // when
+        val buildName = includedBuilds.keys.first().substringAfterLast("/")
+        val result = runGradle(":$buildName:dependencies", "--configuration", "implementation")
+
+        // then
+        result.buildOutcome shouldBe BUILD_SUCCESSFUL
+        result.output should containInOrder(fixture.anotherPluginId, fixture.somePluginId)
     }
 }

--- a/src/test/kotlin/dev/panuszewski/gradle/ConventionPluginsSpec.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/ConventionPluginsSpec.kt
@@ -330,7 +330,7 @@ class ConventionPluginsSpec : GradleSpec() {
 
     @ParameterizedTest
     @SupportedIncludedBuilds
-    fun `should order plugin marker dependencies by alias`(includedBuild: Fixture<*>) {
+    fun `should order plugin marker dependencies for predictable build cache hashes`(includedBuild: Fixture<*>) {
         // given
         installFixture(includedBuild)
         val fixture = installFixture(MultipleConventionPlugins)

--- a/src/test/kotlin/dev/panuszewski/gradle/fixtures/MultipleConventionPlugins.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/fixtures/MultipleConventionPlugins.kt
@@ -1,0 +1,56 @@
+package dev.panuszewski.gradle.fixtures
+
+import dev.panuszewski.gradle.framework.GradleSpec
+import dev.panuszewski.gradle.framework.NoConfigFixture
+
+object MultipleConventionPlugins : NoConfigFixture {
+    const val somePluginId = "pl.allegro.tech.build.axion-release"
+    const val somePluginVersion = "1.18.16"
+
+    const val anotherPluginId = "com.github.ben-manes.versions"
+    const val anotherPluginVersion = "0.52.0"
+
+    override fun GradleSpec.install() {
+        installFixture(TypesafeConventionsAppliedToIncludedBuild)
+
+        libsVersionsToml {
+            """
+            [plugins]
+            some-plugin = { id = "$somePluginId", version = "$somePluginVersion" }
+            another-plugin = { id = "$anotherPluginId", version = "$anotherPluginVersion" }
+            """
+        }
+
+        includedBuild {
+            customProjectFile("src/main/kotlin/some-plugin.gradle.kts") {
+                """
+                plugins {
+                    alias(libs.plugins.some.plugin)
+                    alias(libs.plugins.another.plugin)
+                }
+                """
+            }
+
+            customProjectFile("src/main/kotlin/another-plugin.gradle.kts") {
+                """
+                plugins {
+                    alias(libs.plugins.another.plugin)
+                    alias(libs.plugins.some.plugin)
+                }
+                """
+            }
+
+            buildGradleKts {
+                """
+                plugins {
+                    `kotlin-dsl`
+                }
+
+                repositories {
+                    gradlePluginPortal()
+                }
+                """
+            }
+        }
+    }
+}

--- a/src/test/kotlin/dev/panuszewski/gradle/fixtures/MultipleConventionPlugins.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/fixtures/MultipleConventionPlugins.kt
@@ -22,7 +22,7 @@ object MultipleConventionPlugins : NoConfigFixture {
         }
 
         includedBuild {
-            customProjectFile("src/main/kotlin/some-plugin.gradle.kts") {
+            customProjectFile("src/main/kotlin/first-convention.gradle.kts") {
                 """
                 plugins {
                     alias(libs.plugins.some.plugin)
@@ -31,7 +31,7 @@ object MultipleConventionPlugins : NoConfigFixture {
                 """
             }
 
-            customProjectFile("src/main/kotlin/another-plugin.gradle.kts") {
+            customProjectFile("src/main/kotlin/second-convention.gradle.kts") {
                 """
                 plugins {
                     alias(libs.plugins.another.plugin)


### PR DESCRIPTION
Fixes #138

Let's sort/deduplicate the plugins by alias. This way, the order of automatically added plugin marker dependencies will no longer depend on the inherently unstable FileTree iteration behaviour.